### PR TITLE
fix: disable import when filename is empty for PGN save option

### DIFF
--- a/src/features/boards/components/ImportModal.tsx
+++ b/src/features/boards/components/ImportModal.tsx
@@ -154,7 +154,7 @@ export default function ImportModal({ context, id }: ContextModalProps<{ modalBo
     .exhaustive();
 
   const disabled = match(importType)
-    .with("PGN", () => !pgnTarget.target)
+    .with("PGN", () => !pgnTarget.target || (save && !filename.trim()))
     .with("Link", () => !link)
     .with("FEN", () => !fen)
     .exhaustive();


### PR DESCRIPTION
## Description

Importing a PGN without a name caused an infinite load. The Import button is now disabled if the file name is empty.

## Steps to Reproduce

- Navigate to Board section.
- Click Import
- Paste a PGN into the PGN Game InputBox
- Leave the Name empty
- Click Import

## Type of change
- [x] Bug fix