### PR TITLE
feat: migrate to BCP-47 format (en-US, fr-FR, etc)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import "@/styles/global.css";
 import { documentDir, homeDir, resolve } from "@tauri-apps/api/path";
 import ErrorComponent from "@/common/components/ErrorComponent";
 import { commands } from "./bindings";
+import i18n from "./i18n";
 import { routeTree } from "./routeTree.gen";
 import { ThemeProvider } from "./themes";
 import { openFile } from "./utils/files";
@@ -101,8 +102,7 @@ export default function App() {
   }, [fontSize]);
 
   useEffect(() => {
-    const dir = localStorage.getItem("lang") === "ar_SA" ? "rtl" : "ltr";
-    document.documentElement.setAttribute("dir", dir);
+    document.documentElement.setAttribute("dir", i18n.dir());
   }, []);
 
   return (

--- a/src/common/components/MoveCell.tsx
+++ b/src/common/components/MoveCell.tsx
@@ -58,7 +58,7 @@ const MoveCell = forwardRef(function MoveCell(props: MoveCellProps, ref: Forward
       onContextMenu={props.onContextMenu}
     >
       {props.isStart && <IconFlag style={{ marginRight: 5 }} size="0.875rem" />}
-      {t("{{move, moveNotation}}", { move: props.move })}
+      {t("Formatters.MoveNotation", { move: props.move })}
       {props.annotations.join("")}
     </Box>
   );

--- a/src/common/components/panels/database/GamesTable.tsx
+++ b/src/common/components/panels/database/GamesTable.tsx
@@ -82,7 +82,7 @@ function GamesTable({ games, loading }: { games: NormalizedGame[]; loading: bool
         {
           accessor: "date",
           render: ({ date }) =>
-            t("{{date, dateformat}}", { date: parseDate(date), interpolation: { escapeValue: false } }),
+            t("Formatters.DateFormat", { date: parseDate(date), interpolation: { escapeValue: false } }),
         },
         { accessor: "result" },
         { accessor: "ply_count" },

--- a/src/common/components/panels/database/OpeningsTable.tsx
+++ b/src/common/components/panels/database/OpeningsTable.tsx
@@ -59,7 +59,7 @@ function OpeningsTable({ openings, loading }: { openings: Opening[]; loading: bo
                   Game end
                 </Text>
               );
-            return <Text fz="sm">{t("{{move, moveNotation}}", { move })}</Text>;
+            return <Text fz="sm">{t("Formatters.MoveNotation", { move })}</Text>;
           },
         },
         {

--- a/src/common/components/panels/practice/PracticePanel.tsx
+++ b/src/common/components/panels/practice/PracticePanel.tsx
@@ -160,7 +160,7 @@ function PracticePanel() {
                         {t("Board.Practice.PracticedAll1")}
                         <br />
                         {t("Board.Practice.PracticedAll2")}{" "}
-                        {t("{{date, datetimeformat}}", {
+                        {t("Formatters.DateTimeFormat", {
                           date: stats.nextDue ? new Date(stats.nextDue) : undefined,
                           interpolation: { escapeValue: false },
                         })}

--- a/src/features/accounts/components/AccountCard.tsx
+++ b/src/features/accounts/components/AccountCard.tsx
@@ -328,7 +328,7 @@ export function AccountCard({
       <Accordion.Panel px="0" py="md">
         <SimpleGrid cols={2}>{items}</SimpleGrid>
         <Text mt="xs" size="xs" c="dimmed" ta="right">
-          {`Last update: ${t("{{date, dateformat}}", {
+          {`Last update: ${t("Formatters.DateFormat", {
             date: parseDate(updatedAt),
             interpolation: { escapeValue: false },
           })}`}

--- a/src/features/accounts/components/PersonalCardPanels/TimeRangeSlider.tsx
+++ b/src/features/accounts/components/PersonalCardPanels/TimeRangeSlider.tsx
@@ -25,7 +25,7 @@ const TimeRangeSlider = ({ ratingDates, dateRange, onDateRangeChange }: TimeRang
     <RangeSlider
       pt="lg"
       label={(value) =>
-        t("{{date, dateformat}}", {
+        t("Formatters.DateFormat", {
           date: new Date(ratingDates[value]),
           interpolation: { escapeValue: false },
         })

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -530,7 +530,7 @@ export default function DashboardPage() {
             </Text>
             <Group gap="xs" mt="xs">
               <Button radius="md" onClick={PLAY_CHESS.onClick} leftSection={<IconChess size={18} />}>
-                {t(PLAY_CHESS.label)}
+                {PLAY_CHESS.label}
               </Button>
               <Button
                 variant="light"
@@ -857,7 +857,7 @@ export default function DashboardPage() {
                               <Text size="xs">{userAccount.username}</Text>
                             </Table.Td>
                             <Table.Td c="dimmed">
-                              {t("{{date, dateformat}}", {
+                              {t("Formatters.DateFormat", {
                                 date: new Date(g.end_time * 1000),
                                 interpolation: { escapeValue: false },
                               })}
@@ -955,7 +955,7 @@ export default function DashboardPage() {
                               <Text size="xs">{userAccount.user?.name}</Text>
                             </Table.Td>
                             <Table.Td c="dimmed">
-                              {t("{{date, dateformat}}", {
+                              {t("Formatters.DateFormat", {
                                 date: new Date(g.createdAt),
                                 interpolation: { escapeValue: false },
                               })}

--- a/src/features/databases/components/GameTable.tsx
+++ b/src/features/databases/components/GameTable.tsx
@@ -266,7 +266,7 @@ function GameTable() {
               sortable: true,
               title: t("GameTable.Date"),
               render: ({ date }) =>
-                t("{{date, dateformat}}", {
+                t("Formatters.DateFormat", {
                   date: parseDate(date),
                   interpolation: { escapeValue: false },
                 }),

--- a/src/features/databases/components/TournamentCard.tsx
+++ b/src/features/databases/components/TournamentCard.tsx
@@ -196,7 +196,7 @@ function TournamentCard({ tournament, file }: { tournament: Event; file: string 
                   accessor: "date",
                   sortable: true,
                   render: ({ date }) =>
-                    t("{{date, dateformat}}", { date: parseDate(date), interpolation: { escapeValue: false } }),
+                    t("Formatters.DateFormat", { date: parseDate(date), interpolation: { escapeValue: false } }),
                 },
                 { accessor: "result" },
                 { accessor: "ply_count", sortable: true },

--- a/src/features/files/components/DirectoryTable.tsx
+++ b/src/features/files/components/DirectoryTable.tsx
@@ -268,7 +268,7 @@ function Table({
             if (row.type === "directory") return null;
             return (
               <Box ml={20 * depth}>
-                {t("{{date, datetimeformat}}", {
+                {t("Formatters.DateTimeFormat", {
                   date: new Date(row.lastModified * 1000),
                   interpolation: { escapeValue: false },
                 })}

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -52,10 +52,8 @@ interface SettingItem {
 
 export default function Page() {
   const { t, i18n } = useTranslation();
-  const { setDirection, dir } = useDirection();
+  const { setDirection } = useDirection();
   const [search, setSearch] = useState("");
-
-  console.log(dir);
 
   const [isNative, setIsNative] = useAtom(nativeBarAtom);
   const {
@@ -81,11 +79,9 @@ export default function Page() {
   const languages = useMemo(() => {
     const langs: { value: string; label: string }[] = [];
     for (const localeCode of Object.keys(i18n.services.resourceStore.data)) {
-      // Not sure why it's an exception in the init of our i18n. But to produce the same list I'll normalize it
-      const normalizedCode = localeCode === "en" ? "en_US" : localeCode;
       // Load label from specific namespace, in the other language resource.
       // Would avoid having to load full files if all the translations weren't all already loaded in memory
-      langs.push({ value: normalizedCode, label: t("language:DisplayName", { lng: normalizedCode }) });
+      langs.push({ value: localeCode, label: t("language:DisplayName", { lng: localeCode }) });
     }
     langs.sort((a, b) => a.label.localeCompare(b.label));
     return langs;
@@ -465,14 +461,9 @@ export default function Page() {
               data={languages}
               value={i18n.language}
               onChange={(val) => {
-                i18n.changeLanguage(val || "en_US");
-                localStorage.setItem("lang", val || "en_US");
-
-                if (val === "ar_SA") {
-                  setDirection("rtl");
-                } else {
-                  setDirection("ltr");
-                }
+                i18n.changeLanguage(val || "en-US");
+                localStorage.setItem("lang", val || "en-US");
+                setDirection(i18n.dir());
               }}
             />
           </Group>
@@ -749,7 +740,7 @@ export default function Page() {
   return (
     <Box h="100%" style={{ overflow: "hidden" }}>
       <Title order={1} fw={500} p="lg" className={classes.title}>
-        {t("Settings")}
+        {t("SideBar.Settings")}
       </Title>
       <TextInput
         placeholder={t("Settings.SearchPlaceholder")}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,91 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import {
+  createBytesFormatter,
+  createBytesLongFormatter,
+  createDateFormatter,
+  createDatetimeFormatter,
+  createDurationFormatter,
+  createDurationLongFormatter,
+  createMoveNotationFormatter,
+  createNodesFormatter,
+  createNodesLongFormatter,
+  createScoreFormatter,
+} from "./utils/format";
+
+const isDev = import.meta.env.DEV;
+
+// Import all translation files
+import { ar_SA } from "./translation/ar_SA";
+import { be_BY } from "./translation/be_BY";
+import { en_US } from "./translation/en_US";
+import { es_ES } from "./translation/es_ES";
+import { fr_FR } from "./translation/fr_FR";
+import { hy_AM } from "./translation/hy_AM";
+import { it_IT } from "./translation/it_IT";
+import { ja_JP } from "./translation/ja_JP";
+import { nb_NO } from "./translation/nb_NO";
+import { pl_PL } from "./translation/pl_PL";
+import { pt_PT } from "./translation/pt_PT";
+import { ru_RU } from "./translation/ru_RU";
+import { tr_TR } from "./translation/tr_TR";
+import { uk_UA } from "./translation/uk_UA";
+import { zh_CN } from "./translation/zh_CN";
+
+let lang = localStorage.getItem("lang");
+if (lang) {
+  // Migrate from _ to - from the old format
+  lang = lang.replace("_", "-");
+  localStorage.setItem("lang", lang);
+}
+
+const resources = {
+  "en-US": en_US,
+  "be-BY": be_BY,
+  "es-ES": es_ES,
+  "fr-FR": fr_FR,
+  "hy-AM": hy_AM,
+  "it-IT": it_IT,
+  "ja-JP": ja_JP,
+  "nb-NO": nb_NO,
+  "pl-PL": pl_PL,
+  "pt-PT": pt_PT,
+  "ru-RU": ru_RU,
+  "tr-TR": tr_TR,
+  "uk-UA": uk_UA,
+  "zh-CN": zh_CN,
+  "ar-SA": ar_SA,
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+
+  // Language configuration
+  lng: lang || "en-US",
+  fallbackLng: "en-US",
+
+  // Namespace configuration
+  ns: ["language", "translation"],
+  defaultNS: "translation",
+  fallbackNS: "translation",
+
+  // Debug configuration (set to true for development)
+  debug: isDev,
+
+  // Load configuration
+  load: "currentOnly",
+});
+
+// Add custom formatters
+i18n.services.formatter?.add("bytes", createBytesFormatter(i18n));
+i18n.services.formatter?.add("bytesLong", createBytesLongFormatter(i18n));
+i18n.services.formatter?.add("nodes", createNodesFormatter(i18n));
+i18n.services.formatter?.add("nodesLong", createNodesLongFormatter(i18n));
+i18n.services.formatter?.add("duration", createDurationFormatter(i18n));
+i18n.services.formatter?.add("durationLong", createDurationLongFormatter(i18n));
+i18n.services.formatter?.add("score", createScoreFormatter(i18n));
+i18n.services.formatter?.add("dateformat", createDateFormatter(i18n, localStorage));
+i18n.services.formatter?.add("datetimeformat", createDatetimeFormatter(i18n, localStorage));
+i18n.services.formatter?.add("moveNotation", createMoveNotationFormatter(i18n, localStorage));
+
+export default i18n;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,68 +1,6 @@
-import i18n from "i18next";
 import { createRoot } from "react-dom/client";
-import { initReactI18next } from "react-i18next";
 import App from "./App";
-import { ar_SA } from "./translation/ar_SA";
-import { be_BY } from "./translation/be_BY";
-import { en_US } from "./translation/en_US";
-import { es_ES } from "./translation/es_ES";
-import { fr_FR } from "./translation/fr_FR";
-import { hy_AM } from "./translation/hy_AM";
-import { it_IT } from "./translation/it_IT";
-import { ja_JP } from "./translation/ja_JP";
-import { nb_NO } from "./translation/nb_NO";
-import { pl_PL } from "./translation/pl_PL";
-import { pt_PT } from "./translation/pt_PT";
-import { ru_RU } from "./translation/ru_RU";
-import { tr_TR } from "./translation/tr_TR";
-import { uk_UA } from "./translation/uk_UA";
-import { zh_CN } from "./translation/zh_CN";
-import {
-  createBytesFormatter,
-  createBytesLongFormatter,
-  createDateFormatter,
-  createDatetimeFormatter,
-  createDurationFormatter,
-  createDurationLongFormatter,
-  createMoveNotationFormatter,
-  createNodesFormatter,
-  createNodesLongFormatter,
-  createScoreFormatter,
-} from "./utils/format";
-
-i18n.use(initReactI18next).init({
-  resources: {
-    en: en_US,
-    be_BY: be_BY,
-    es_ES: es_ES,
-    fr_FR: fr_FR,
-    hy_AM: hy_AM,
-    it_IT: it_IT,
-    ja_JP: ja_JP,
-    nb_NO: nb_NO,
-    pl_PL: pl_PL,
-    pt_PT: pt_PT,
-    ru_RU: ru_RU,
-    tr_TR: tr_TR,
-    uk_UA: uk_UA,
-    zh_CN: zh_CN,
-    ar_SA: ar_SA,
-  },
-  lng: localStorage.getItem("lang") || "en_US",
-  fallbackLng: "en",
-});
-
-// Add custom formatters
-i18n.services.formatter?.add("bytes", createBytesFormatter(i18n));
-i18n.services.formatter?.add("bytesLong", createBytesLongFormatter(i18n));
-i18n.services.formatter?.add("nodes", createNodesFormatter(i18n));
-i18n.services.formatter?.add("nodesLong", createNodesLongFormatter(i18n));
-i18n.services.formatter?.add("duration", createDurationFormatter(i18n));
-i18n.services.formatter?.add("durationLong", createDurationLongFormatter(i18n));
-i18n.services.formatter?.add("score", createScoreFormatter(i18n));
-i18n.services.formatter?.add("dateformat", createDateFormatter(i18n, localStorage));
-i18n.services.formatter?.add("datetimeformat", createDatetimeFormatter(i18n, localStorage));
-i18n.services.formatter?.add("moveNotation", createMoveNotationFormatter(i18n, localStorage));
+import "./i18n"; // Import the new i18n configuration
 
 const container = document.getElementById("app");
 const root = createRoot(container!);

--- a/src/translation/ar_SA.ts
+++ b/src/translation/ar_SA.ts
@@ -154,5 +154,16 @@ export const ar_SA = {
     "Settings.Appearance.hideDashboardOnStartup": "إخفاء لوحة التحكم عند بدء التشغيل",
     "Settings.Appearance.hideDashboardOnStartup.Desc": "افتح اللوحات بدلًا من لوحة التحكم عند بدء التطبيق",
     "Puzzle.JumpToNextPuzzleImmediately": "انتقل فورًا إلى اللغز التالي",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/be_BY.ts
+++ b/src/translation/be_BY.ts
@@ -342,5 +342,16 @@ export const be_BY = {
     "PgnInput.ExtraMarkups": "Дадатковыя пазнакі",
     "PgnInput.MaxDepth": "Максімальная глыбіня",
     "PgnInput.TotalMoves": "Агульная колькасць хадоў",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/de_DE.ts
+++ b/src/translation/de_DE.ts
@@ -594,5 +594,16 @@ export const de_DE = {
     "PgnInput.MaxDepth": "Maximale Tiefe",
     "PgnInput.TotalMoves": "Gesamtzüge",
     "Puzzle.JumpToNextPuzzleImmediately": "Sofort zum nächsten Puzzle springen",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/en_US.ts
+++ b/src/translation/en_US.ts
@@ -619,5 +619,16 @@ export const en_US = {
     "Tablebase.DTM": "DTM {{count}}",
     "Tablebase.DTZ": "DTZ {{count}}",
     "Tablebase.FiftyMoveRule": "*due to the 50-move rule",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/es_ES.ts
+++ b/src/translation/es_ES.ts
@@ -598,5 +598,16 @@ export const es_ES = {
     "PgnInput.MaxDepth": "Profundidad máxima",
     "PgnInput.TotalMoves": "Movimientos totales",
     "Puzzle.JumpToNextPuzzleImmediately": "Saltar al siguiente puzzle inmediatamente",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/fr_FR.ts
+++ b/src/translation/fr_FR.ts
@@ -590,5 +590,16 @@ export const fr_FR = {
     "Lessons.ExercisesCompleted": "exercices terminés",
     "Lessons.LessonCompleted": "Félicitations ! Vous avez terminé {{lesson}} !",
     "Lessons.CompletionMessage": "Vous avez terminé tous les exercices de cette leçon. Continuez ainsi !",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/hy_AM.ts
+++ b/src/translation/hy_AM.ts
@@ -588,5 +588,16 @@ export const hy_AM = {
     "Tablebase.FiftyMoveRule": "*ըստ 50 քայլի կանոնի",
     "PgnInput.TotalMoves": "Ընդհանուր քայլեր",
     "Puzzle.JumpToNextPuzzleImmediately": "Անմիջապես անցնել հաջորդ խնդրին",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/it_IT.ts
+++ b/src/translation/it_IT.ts
@@ -594,5 +594,16 @@ export const it_IT = {
     "PgnInput.MaxDepth": "Profondità Massima",
     "PgnInput.TotalMoves": "Totale di Mosse",
     "Puzzle.JumpToNextPuzzleImmediately": "Passa immediatamente al puzzle successivo",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/ja_JP.ts
+++ b/src/translation/ja_JP.ts
@@ -53,5 +53,16 @@ export const ja_JP = {
     "Common.UnsavedChanges.Desc": "未保存の変更があります。閉じる前に保存しますか？",
     "Common.SaveAndClose": "保存して閉じる",
     "Common.CloseWithoutSaving": "保存せずに閉じる",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/nb_NO.ts
+++ b/src/translation/nb_NO.ts
@@ -341,5 +341,16 @@ export const nb_NO = {
     "PgnInput.TotalMoves": "Totalt antall trekk",
 
     "Puzzle.JumpToNextPuzzleImmediately": "Hopp til neste oppgave umiddelbart",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/pl_PL.ts
+++ b/src/translation/pl_PL.ts
@@ -342,5 +342,16 @@ export const pl_PL = {
     "PgnInput.ExtraMarkups": "Dodatkowe oznaczenia",
     "PgnInput.MaxDepth": "Maksymalna głębokość",
     "PgnInput.TotalMoves": "Całkowita liczba ruchów",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/pt_PT.ts
+++ b/src/translation/pt_PT.ts
@@ -341,5 +341,16 @@ export const pt_PT = {
     "PgnInput.ExtraMarkups": "Anotações extras",
     "PgnInput.MaxDepth": "Profundidade máxima",
     "PgnInput.TotalMoves": "Total de jogadas",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/ru_RU.ts
+++ b/src/translation/ru_RU.ts
@@ -588,5 +588,16 @@ export const ru_RU = {
     "PgnInput.MaxDepth": "Максимальная глубина",
     "PgnInput.TotalMoves": "Всего ходов",
     "Puzzle.JumpToNextPuzzleImmediately": "Сразу переходить к следующей головоломке",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/tr_TR.ts
+++ b/src/translation/tr_TR.ts
@@ -589,5 +589,16 @@ export const tr_TR = {
     "PgnInput.MaxDepth": "Maksimum Derinlik",
     "PgnInput.TotalMoves": "Toplam Hamle",
     "Puzzle.JumpToNextPuzzleImmediately": "Sonraki bulmayaca direkt geç",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/uk_UA.ts
+++ b/src/translation/uk_UA.ts
@@ -339,5 +339,16 @@ export const uk_UA = {
     "PgnInput.ExtraMarkups": "Додаткові позначки",
     "PgnInput.MaxDepth": "Максимальна глибина",
     "PgnInput.TotalMoves": "Загальна кількість ходів",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };

--- a/src/translation/zh_CN.ts
+++ b/src/translation/zh_CN.ts
@@ -579,5 +579,16 @@ export const zh_CN = {
     "Tablebase.FiftyMoveRule": "*因50步规则",
     "PgnInput.MaxDepth": "最大深度",
     "PgnInput.TotalMoves": "总走法",
+
+    "Formatters.DateFormat": "{{date, dateformat}}",
+    "Formatters.DateTimeFormat": "{{date, datetimeformat}}",
+    "Formatters.MoveNotation": "{{move, moveNotation}}",
+    "Formatters.Bytes": "{{bytes, bytes}}",
+    "Formatters.BytesLong": "{{bytes, bytesLong}}",
+    "Formatters.Nodes": "{{nodes, nodes}}",
+    "Formatters.NodesLong": "{{nodes, nodesLong}}",
+    "Formatters.Duration": "{{duration, duration}}",
+    "Formatters.DurationLong": "{{duration, durationLong}}",
+    "Formatters.Score": "{{score, score}}",
   },
 };


### PR DESCRIPTION
<!-- Pull Request Template -->

## Description

- using the proper language code allows to directly use i18n.dir() instead of needing a localStorage
- move all i18next initilization to it's own file
- add Formatters to avoid i18n failing to load a key and searching for fallbacks

## Type of change
- [x] New feature

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
