### PR TITLE
feat: select and paste pieces in position editor

### DIFF
--- a/src/common/components/Piece.tsx
+++ b/src/common/components/Piece.tsx
@@ -1,7 +1,7 @@
 import type { Color, Piece } from "chessground/types";
 import type { Square } from "chessops";
 import { squareFromCoords } from "chessops/util";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import Draggable from "react-draggable";
 
 export default function PieceComponent({
@@ -10,15 +10,27 @@ export default function PieceComponent({
   putPiece,
   size,
   orientation,
+  selectedPiece,
+  onSelect,
 }: {
   piece: Piece;
   boardRef?: React.RefObject<HTMLDivElement>;
   putPiece?: (square: Square, piece: Piece) => void;
   size?: number | string;
   orientation?: Color;
+  selectedPiece: Piece | null;
+  onSelect: (piece: Piece, isDragging: boolean) => void;
 }) {
   size = size || "100%";
   const pieceRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [hasDragged, setHasDragged] = useState(false);
+
+  const handleClick = () => {
+    onSelect(piece, hasDragged);
+    setHasDragged(false);
+  };
+
   if (!boardRef || !putPiece) {
     return (
       <div
@@ -32,6 +44,7 @@ export default function PieceComponent({
       />
     );
   }
+
   const handleDrop = (position: { x: number; y: number }) => {
     const boardRect = boardRef?.current?.getBoundingClientRect();
     if (
@@ -60,9 +73,14 @@ export default function PieceComponent({
     <Draggable
       nodeRef={pieceRef}
       position={{ x: 0, y: 0 }}
+      onDrag={() => {
+        setIsDragging(true);
+        setHasDragged(true);
+      }}
       onStop={(e) => {
         const { clientX, clientY } = e as MouseEvent;
         handleDrop({ x: clientX, y: clientY });
+        setIsDragging(false);
       }}
       scale={1}
     >
@@ -74,7 +92,12 @@ export default function PieceComponent({
           backgroundRepeat: "no-repeat",
           backgroundPosition: "center",
           zIndex: 100,
+          backgroundColor:
+            !isDragging && selectedPiece && piece.role === selectedPiece.role && piece.color === selectedPiece.color
+              ? "var(--mantine-primary-color-filled)"
+              : "transparent",
         }}
+        onClick={handleClick}
       />
     </Draggable>
   );

--- a/src/common/components/boards/Board.tsx
+++ b/src/common/components/boards/Board.tsx
@@ -22,6 +22,7 @@ import { documentDir, homeDir } from "@tauri-apps/api/path";
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeFile } from "@tauri-apps/plugin-fs";
 import type { DrawShape } from "chessground/draw";
+import type { Piece } from "chessground/types";
 import { makeSquare, type NormalMove, parseSquare, parseUci, type SquareName } from "chessops";
 import { chessgroundDests, chessgroundMove } from "chessops/compat";
 import { makeSan } from "chessops/san";
@@ -86,6 +87,8 @@ interface ChessboardProps {
   whiteTime?: number;
   blackTime?: number;
   practicing?: boolean;
+  selectedPiece: Piece | null;
+  setSelectedPiece: (piece: Piece | null) => void;
 }
 
 function Board({
@@ -103,6 +106,8 @@ function Board({
   whiteTime,
   blackTime,
   practicing,
+  selectedPiece,
+  setSelectedPiece,
 }: ChessboardProps) {
   const { t } = useTranslation();
 
@@ -424,12 +429,12 @@ function Board({
       : editingMode
         ? "both"
         : match(movable)
-            .with("white", () => "white" as const)
-            .with("black", () => "black" as const)
-            .with("turn", () => turn)
-            .with("both", () => "both" as const)
-            .with("none", () => undefined)
-            .exhaustive();
+          .with("white", () => "white" as const)
+          .with("black", () => "black" as const)
+          .with("turn", () => turn)
+          .with("both", () => "both" as const)
+          .with("none", () => undefined)
+          .exhaustive();
   }, [practiceLock, editingMode, movable, turn]);
 
   const theme = useMantineTheme();
@@ -540,9 +545,9 @@ function Board({
               style={
                 isBasicAnnotation(currentNode.annotations[0])
                   ? {
-                      "--light-color": lightColor,
-                      "--dark-color": darkColor,
-                    }
+                    "--light-color": lightColor,
+                    "--dark-color": darkColor,
+                  }
                   : undefined
               }
               className={chessboard}
@@ -577,6 +582,8 @@ function Board({
               />
 
               <Chessground
+                selectedPiece={selectedPiece}
+                setSelectedPiece={setSelectedPiece}
                 setBoardFen={setBoardFen}
                 orientation={orientation}
                 fen={currentNode.fen}

--- a/src/common/components/boards/BoardAnalysis.tsx
+++ b/src/common/components/boards/BoardAnalysis.tsx
@@ -10,8 +10,9 @@ import {
 } from "@tabler/icons-react";
 import { useLoaderData } from "@tanstack/react-router";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
+import type { Piece } from "chessground/types";
 import { useAtom, useAtomValue } from "jotai";
-import { Suspense, useCallback, useContext, useEffect, useRef } from "react";
+import { Suspense, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import GameNotation from "@/common/components/GameNotation";
@@ -43,6 +44,7 @@ function BoardAnalysis() {
   const { t } = useTranslation();
 
   const [editingMode, toggleEditingMode] = useToggle();
+  const [selectedPiece, setSelectedPiece] = useState<Piece | null>(null);
   const [currentTab, setCurrentTab] = useAtom(currentTabAtom);
   const autoSave = useAtomValue(autoSaveAtom);
   const { documentDir } = useLoaderData({ from: "/boards" });
@@ -164,6 +166,8 @@ function BoardAnalysis() {
           saveFile={saveFile}
           reload={reloadBoard}
           addGame={addGame}
+          selectedPiece={selectedPiece}
+          setSelectedPiece={setSelectedPiece}
         />
       </Portal>
       <Portal target="#topRight" style={{ height: "100%" }}>
@@ -250,7 +254,12 @@ function BoardAnalysis() {
       </Portal>
       <Portal target="#bottomRight" style={{ height: "100%" }}>
         {editingMode ? (
-          <EditingCard boardRef={boardRef} setEditingMode={toggleEditingMode} />
+          <EditingCard
+            boardRef={boardRef}
+            setEditingMode={toggleEditingMode}
+            selectedPiece={selectedPiece}
+            setSelectedPiece={setSelectedPiece}
+          />
         ) : (
           <Stack h="100%" gap="xs">
             <GameNotation topBar />

--- a/src/common/components/boards/EditingCard.tsx
+++ b/src/common/components/boards/EditingCard.tsx
@@ -5,13 +5,18 @@ import { TreeStateContext } from "@/common/components/TreeStateContext";
 import FenInput from "../panels/info/FenInput";
 import * as classes from "./EditingCard.css";
 import PiecesGrid from "./PiecesGrid";
+import type { Piece } from "chessground/types";
 
 function EditingCard({
   boardRef,
   setEditingMode,
+  selectedPiece,
+  setSelectedPiece,
 }: {
   boardRef: React.MutableRefObject<HTMLDivElement | null>;
   setEditingMode: (editing: boolean) => void;
+  selectedPiece: Piece | null;
+  setSelectedPiece: (piece: Piece | null) => void;
 }) {
   const store = useContext(TreeStateContext)!;
   const fen = useStore(store, (s) => s.currentNode().fen);
@@ -30,6 +35,8 @@ function EditingCard({
           setFen(newFen);
         }}
         orientation={headers.orientation}
+        selectedPiece={selectedPiece}
+        setSelectedPiece={setSelectedPiece}
       />
     </Card>
   );

--- a/src/common/components/boards/PiecesGrid.tsx
+++ b/src/common/components/boards/PiecesGrid.tsx
@@ -2,6 +2,7 @@ import { SimpleGrid } from "@mantine/core";
 import { COLORS, ROLES } from "chessops";
 import { makeFen, parseFen } from "chessops/fen";
 import Piece from "@/common/components/Piece";
+import type { Piece as PieceType } from "chessground/types";
 
 function PiecesGrid({
   fen,
@@ -9,13 +10,25 @@ function PiecesGrid({
   vertical,
   onPut,
   orientation = "white",
+  selectedPiece,
+  setSelectedPiece,
 }: {
   fen: string;
   boardRef: React.MutableRefObject<HTMLDivElement | null>;
   onPut: (newFen: string) => void;
   vertical?: boolean;
   orientation?: "white" | "black";
+  selectedPiece: PieceType | null;
+  setSelectedPiece: (piece: PieceType | null) => void;
 }) {
+  const handlePieceSelect = (piece: PieceType, isDragging: boolean) => {
+    if (!isDragging && selectedPiece && piece.role === selectedPiece.role && piece.color === selectedPiece.color) {
+      setSelectedPiece(null);
+    } else {
+      setSelectedPiece(piece);
+    }
+  };
+
   return (
     <SimpleGrid cols={vertical ? 2 : 6} flex={1} w="100%">
       {COLORS.map((color) =>
@@ -34,6 +47,8 @@ function PiecesGrid({
               color,
             }}
             orientation={orientation}
+            onSelect={handlePieceSelect}
+            selectedPiece={selectedPiece}
           />
         )),
       )}


### PR DESCRIPTION
## Description

Enable a persistent click-to-place interaction in position editor: Click a piece in the palette to select it, then click any square to place it.  The selection remains until cleared by clicking the selected piece again, choose a different piece, or exit edit mode. This lets you place many of the same piece quickly (like multiple pawns) without having to keep dragging and dropping the same piece over and over.

## Type of change
- [x] New feature
