### PR TITLE
fix: untitled games

### DIFF
--- a/src/common/components/panels/info/GameSelector.tsx
+++ b/src/common/components/panels/info/GameSelector.tsx
@@ -73,7 +73,9 @@ export default function GameSelector({
     if (games.size === 0 && total > 0) {
       loadMoreRows(0, Math.min(10, total - 1));
     }
+  }, [games.size, total, loadMoreRows]);
 
+  useEffect(() => {
     const items = rowVirtualizer.getVirtualItems();
     const unloadedItems = items.filter((item) => !isRowLoaded(item.index));
 
@@ -82,7 +84,7 @@ export default function GameSelector({
       const stopIndex = Math.max(...unloadedItems.map((item) => item.index));
       loadMoreRows(startIndex, stopIndex);
     }
-  }, [games.size, total, loadMoreRows, rowVirtualizer]);
+  }, [loadMoreRows, rowVirtualizer.getVirtualItems()]);
 
   return (
     <ScrollArea viewportRef={parentRef} h="100%">


### PR DESCRIPTION
## Description

Related to https://github.com/ChessKitchen/pawn-appetit/issues/64

## Steps to Reproduce
- Import a PGN
- Go to the Info tab to view the game title
- Only the first 11 items shows the correct title

## Type of change
- [x] Bug fix
