### PR TITLE
fix: restore show arrows option

### DIFF
--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -26,6 +26,7 @@ import {
   nativeBarAtom,
   percentageCoverageAtom,
   previewBoardOnHoverAtom,
+  showArrowsAtom,
   showConsecutiveArrowsAtom,
   showCoordinatesAtom,
   showDestsAtom,
@@ -148,6 +149,23 @@ export default function Page() {
               </Text>
             </div>
             <SettingsSwitch atom={showDestsAtom} />
+          </Group>
+        ),
+      },
+      {
+        id: "arrows",
+        title: t("settings.board.arrows"),
+        description: t("settings.board.arrowsDesc"),
+        tab: "board",
+        component: (
+          <Group justify="space-between" wrap="nowrap" gap="xl" className={classes.item}>
+            <div>
+              <Text>{t("settings.board.arrows")}</Text>
+              <Text size="xs" c="dimmed">
+                {t("settings.board.arrowsDesc")}
+              </Text>
+            </div>
+            <SettingsSwitch atom={showArrowsAtom} />
           </Group>
         ),
       },


### PR DESCRIPTION
## Description

Restore the "Show best move arrows" option in the setting page.

## Steps to Reproduce
- Open Settings
- Search for "arrows" 
- The "Show best move arrows" option does not appears

## Type of change
- [x] Bug fix
